### PR TITLE
Add JSON field; support string inputs for MetaobjectAccessInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ await client.applySchema();
 const designers = await tento.metaobjects.designers.list({
   first: 10,
 });
-/* 
+/*
   {
     _id: string;
     _handle: string;
@@ -206,6 +206,7 @@ export const orm = metaobject({
     weight_list: f.weightList({
       validations: (v) => [v.min({ value: 1, unit: "KILOGRAMS" }), v.max({ value: 100, unit: "POUNDS" })],
     }),
+    json: f.json(),
   }),
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drizzle-team/tento",
-  "version": "0.1.3",
+  "version": "0.1.4-alpha.0",
   "repository": "https://github.com/drizzle-team/tento",
   "author": "Drizzle Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "description": "",
   "module": "index.js",
-  "main": "index.cjs",
+  "main": "dist/index.cjs",
+  "files": ["dist"],
   "type": "module",
   "bin": {
     "tento": "./cli/cli.cjs"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "biome lint .",
     "gql": "graphql-codegen --config .graphqlrc.ts",
     "build": "tsx build.ts",
-    "b": "pnpm build"
+    "b": "pnpm build",
+    "postinstall": "tsx build.ts"
   },
   "keywords": [],
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 1.4.1
       '@drizzle-team/tento':
         specifier: link:./dist
-        version: link:dist
+        version: link:node_modules/@drizzle-team/tento
       '@graphql-codegen/cli':
         specifier: ^5.0.0
         version: 5.0.0(@types/node@20.10.3)(graphql@16.8.1)(typescript@5.3.2)

--- a/src/client/field.ts
+++ b/src/client/field.ts
@@ -66,6 +66,7 @@ export const fields = {
 	// fileList,
 	dimension,
 	dimensionList,
+	json,
 	volume,
 	volumeList,
 	weight,
@@ -73,6 +74,23 @@ export const fields = {
 };
 
 export type Fields = typeof fields;
+
+export class JsonField extends Field<string> {
+	constructor(config: MetaobjectFieldDefinitionConfig<JsonFieldValidations>, validations: Validations) {
+		super({ ...config, type: 'json' }, validations);
+	}
+}
+
+export function json<T extends MetaobjectFieldDefinitionConfig<JsonFieldValidations>>(
+	config?: T,
+): JsonField {
+	return new JsonField(config ?? {}, jsonFieldValidations);
+}
+
+export const jsonFieldValidations = {
+};
+
+export type JsonFieldValidations = typeof singleLineTextFieldValidations;
 
 export class SingleLineTextField extends Field<string> {
 	constructor(config: MetaobjectFieldDefinitionConfig<SingleLineTextFieldValidations>, validations: Validations) {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -134,12 +134,12 @@ export type MetaobjectAccessInput = {
 	 * Access configuration for Admin API surface areas, including the GraphQL Admin API.
 	 *
 	 */
-	admin?: MetaobjectAdminAccess;
+	admin?: `${MetaobjectAdminAccess}`;
 	/**
 	 * Access configuration for Storefront API surface areas, including the GraphQL Storefront API and Liquid.
 	 *
 	 */
-	storefront?: MetaobjectStorefrontAccess;
+	storefront?: `${MetaobjectStorefrontAccess}`;
 };
 
 export type ExtractSchema<TSchema extends Record<string, unknown>> = Simplify<{

--- a/tests/src/schema.ts
+++ b/tests/src/schema.ts
@@ -3,6 +3,10 @@ import { metaobject } from '@drizzle-team/tento';
 export const orm = metaobject({
 	name: 'ORM',
 	type: 'orm',
+	access: {
+		admin: "PUBLIC_READ",
+		storefront: "PUBLIC_READ",
+	},
 	fieldDefinitions: (f) => ({
 		name: f.singleLineTextField({
 			name: 'Name',
@@ -68,6 +72,7 @@ export const orm = metaobject({
 		weight_list: f.weightList({
 			validations: (v) => [v.min({ value: 1, unit: "KILOGRAMS" }), v.max({ value: 100, unit: "POUNDS" })],
 		}),
+		json: f.json(),
 	}),
 });
 


### PR DESCRIPTION
* Adds `f.json()`
* I don't think the enums were available for `MetaobjectAccessInput` to be used at all.
* The `package.json` changes can be removed; I was just trying to test this locally.

EDIT: Is JSON Schema validator available via API? [Looks like yes.](https://shopify.dev/docs/apps/custom-data/metafields/definitions/validation#json-schema)
<img width="615" alt="image" src="https://github.com/drizzle-team/tento/assets/1060689/7fd835e3-8469-4ebe-a81c-240ad1e4aacf">